### PR TITLE
Fix safety bugs

### DIFF
--- a/ncnn-rs/examples/benchmark.rs
+++ b/ncnn-rs/examples/benchmark.rs
@@ -9,8 +9,8 @@ fn param_path() -> std::path::PathBuf {
     path
 }
 
-fn benchmark(name: &str, mat_in: &Mat, opt: &ncnn_option, out: &str) {
-    let mat_out = Mat::new();
+fn benchmark(name: &str, mut mat_in: Mat, opt: &ncnn_option, out: &str) {
+    let mut mat_out = Mat::new();
     mat_in.fill(1.0 as f32);
 
     let net = Net::new();
@@ -27,16 +27,16 @@ fn benchmark(name: &str, mat_in: &Mat, opt: &ncnn_option, out: &str) {
     net.load_model_datareader(&dr);
 
     // warmup
-    let ex_warmup = net.create_extractor();
+    let mut ex_warmup = net.create_extractor();
     ex_warmup.input("data", &mat_in);
-    ex_warmup.extract(out, &mat_out);
+    ex_warmup.extract(out, &mut mat_out);
 
     let loop_cnt = 10;
     let now = time::Instant::now();
     for _ in 0..loop_cnt {
-        let ex = net.create_extractor();
+        let mut ex = net.create_extractor();
         ex.input("data", &mat_in);
-        ex.extract(out, &mat_out);
+        ex.extract(out, &mut mat_out);
     }
     let duration = now.elapsed().as_millis() / loop_cnt;
     println!("{} \t\t {} ms", name, duration);
@@ -50,208 +50,208 @@ fn main() {
 
     benchmark(
         "squeezenet.param",
-        &Mat::create_3d(227, 227, 3, &alloc),
+        Mat::create_3d(227, 227, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "squeezenet_int8.param",
-        &Mat::create_3d(227, 227, 3, &alloc),
+        Mat::create_3d(227, 227, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_int8.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_v2.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_v3.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "shufflenet.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "shufflenet_v2.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mnasnet.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "proxylessnasnet.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "efficientnet_b0.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
-    // benchmark("efficientnetv2_b0.param", &Mat::create_3d(224, 224, 3, &alloc), &opt, "output");
+    // benchmark("efficientnetv2_b0.param", Mat::create_3d(224, 224, 3, &alloc), &opt, "output");
 
     benchmark(
         "regnety_400m.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "blazeface.param",
-        &Mat::create_3d(128, 128, 3, &alloc),
+        Mat::create_3d(128, 128, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "googlenet.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "googlenet_int8.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "resnet18.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "resnet18_int8.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "alexnet.param",
-        &Mat::create_3d(227, 227, 3, &alloc),
+        Mat::create_3d(227, 227, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "vgg16.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "vgg16_int8.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "resnet50.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "resnet50_int8.param",
-        &Mat::create_3d(224, 224, 3, &alloc),
+        Mat::create_3d(224, 224, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "squeezenet_ssd.param",
-        &Mat::create_3d(300, 300, 3, &alloc),
+        Mat::create_3d(300, 300, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "squeezenet_ssd_int8.param",
-        &Mat::create_3d(300, 300, 3, &alloc),
+        Mat::create_3d(300, 300, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_ssd.param",
-        &Mat::create_3d(300, 300, 3, &alloc),
+        Mat::create_3d(300, 300, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_ssd_int8.param",
-        &Mat::create_3d(300, 300, 3, &alloc),
+        Mat::create_3d(300, 300, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenet_yolo.param",
-        &Mat::create_3d(416, 416, 3, &alloc),
+        Mat::create_3d(416, 416, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "mobilenetv2_yolov3.param",
-        &Mat::create_3d(352, 352, 3, &alloc),
+        Mat::create_3d(352, 352, 3, &alloc),
         &opt,
         "output",
     );
 
     benchmark(
         "yolov4-tiny.param",
-        &Mat::create_3d(416, 416, 3, &alloc),
+        Mat::create_3d(416, 416, 3, &alloc),
         &opt,
         "output",
     );
 
-    // benchmark("nanodet_m.param", &Mat::create_3d(320, 320, 3, &alloc), &opt, "output");
+    // benchmark("nanodet_m.param", Mat::create_3d(320, 320, 3, &alloc), &opt, "output");
 }

--- a/ncnn-rs/examples/benchmark.rs
+++ b/ncnn-rs/examples/benchmark.rs
@@ -13,7 +13,7 @@ fn benchmark(name: &str, mut mat_in: Mat, opt: &ncnn_option, out: &str) {
     let mut mat_out = Mat::new();
     mat_in.fill(1.0 as f32);
 
-    let net = Net::new();
+    let mut net = Net::new();
     let path = param_path().join("../params").join(name);
     if !path.exists() {
         println!("vgg16 param not exist: {:?}", path);
@@ -22,7 +22,7 @@ fn benchmark(name: &str, mut mat_in: Mat, opt: &ncnn_option, out: &str) {
 
     net.set_option(opt);
     net.load_param(path.to_str().unwrap());
-    let dr = DataReader::new();
+    let mut dr = DataReader::new();
     dr.use_empty_config();
     net.load_model_datareader(&dr);
 
@@ -43,7 +43,7 @@ fn benchmark(name: &str, mut mat_in: Mat, opt: &ncnn_option, out: &str) {
 }
 
 fn main() {
-    let opt = ncnn_option::new();
+    let mut opt = ncnn_option::new();
     opt.set_num_threads(1);
 
     let alloc = ncnn_rs::allocator::Allocator::new();

--- a/ncnn-rs/src/allocator.rs
+++ b/ncnn-rs/src/allocator.rs
@@ -22,7 +22,7 @@ impl Allocator {
     //     Allocator { ptr }
     // }
 
-    pub fn get(&self) -> ncnn_allocator_t {
+    pub(crate) fn ptr(&self) -> ncnn_allocator_t {
         self.ptr
     }
 }

--- a/ncnn-rs/src/datareader.rs
+++ b/ncnn-rs/src/datareader.rs
@@ -31,7 +31,7 @@ impl DataReader {
         DataReader { ptr }
     }
 
-    pub fn use_empty_config(&self) {
+    pub fn use_empty_config(&mut self) {
         unsafe {
             (*(self.ptr)).scan = Some(default_scan);
             (*(self.ptr)).read = Some(default_read);
@@ -39,7 +39,7 @@ impl DataReader {
     }
 
     pub fn set_scan(
-        &self,
+        &mut self,
         function_ptr: std::option::Option<
             unsafe extern "C" fn(
                 dr: ncnn_datareader_t,
@@ -54,7 +54,7 @@ impl DataReader {
     }
 
     pub fn set_read(
-        &self,
+        &mut self,
         function_ptr: std::option::Option<
             unsafe extern "C" fn(
                 dr: ncnn_datareader_t,
@@ -68,7 +68,7 @@ impl DataReader {
         }
     }
 
-    pub fn get(&self) -> ncnn_datareader_t {
+    pub(crate) fn ptr(&self) -> ncnn_datareader_t {
         self.ptr
     }
 }

--- a/ncnn-rs/src/mat.rs
+++ b/ncnn-rs/src/mat.rs
@@ -14,28 +14,28 @@ impl Mat {
     }
 
     pub fn create_1d(w: i32, alloc: &ncnn_Allocator) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_1d(w, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_1d(w, alloc.ptr()) };
         Mat { ptr }
     }
 
     pub fn create_2d(w: i32, h: i32, alloc: &ncnn_Allocator) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_2d(w, h, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_2d(w, h, alloc.ptr()) };
         Mat { ptr }
     }
 
     pub fn create_3d(w: i32, h: i32, c: i32, alloc: &ncnn_Allocator) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_3d(w, h, c, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_3d(w, h, c, alloc.ptr()) };
         Mat { ptr }
     }
 
     // same as OpenCV Mat API https://docs.rs/opencv/latest/opencv/core/struct.Mat.html
     pub fn create_external_1d(w: i32, data: *mut c_void, alloc: &ncnn_Allocator) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_external_1d(w, data, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_external_1d(w, data, alloc.ptr()) };
         Mat { ptr }
     }
 
     pub fn create_external_2d(w: i32, h: i32, data: *mut c_void, alloc: &ncnn_Allocator) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_external_2d(w, h, data, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_external_2d(w, h, data, alloc.ptr()) };
         Mat { ptr }
     }
 
@@ -46,7 +46,7 @@ impl Mat {
         data: *mut c_void,
         alloc: &ncnn_Allocator,
     ) -> Mat {
-        let ptr = unsafe { ncnn_mat_create_external_3d(w, h, c, data, alloc.get()) };
+        let ptr = unsafe { ncnn_mat_create_external_3d(w, h, c, data, alloc.ptr()) };
         Mat { ptr }
     }
 
@@ -83,11 +83,11 @@ impl Mat {
         unsafe { ncnn_mat_get_data(self.ptr) }
     }
 
-    pub fn ptr(&self) -> ncnn_mat_t {
+    pub(crate) fn ptr(&self) -> ncnn_mat_t {
         self.ptr
     }
 
-    pub fn mut_ptr(&mut self) -> *mut ncnn_mat_t {
+    pub(crate) fn mut_ptr(&mut self) -> *mut ncnn_mat_t {
         &mut self.ptr
     }
 }

--- a/ncnn-rs/src/mat.rs
+++ b/ncnn-rs/src/mat.rs
@@ -1,4 +1,5 @@
 use crate::allocator::Allocator as ncnn_Allocator;
+use core::fmt;
 use ncnn_bind::*;
 use std::os::raw::c_void;
 
@@ -7,10 +8,6 @@ pub struct Mat {
 }
 
 impl Mat {
-    pub fn get(&self) -> ncnn_mat_t {
-        self.ptr
-    }
-
     pub fn new() -> Mat {
         let ptr = unsafe { ncnn_mat_create() };
         Mat { ptr }
@@ -54,7 +51,7 @@ impl Mat {
     }
 
     // setter
-    pub fn fill(&self, value: f32) {
+    pub fn fill(&mut self, value: f32) {
         unsafe { ncnn_mat_fill_float(self.ptr, value) };
     }
 
@@ -86,16 +83,24 @@ impl Mat {
         unsafe { ncnn_mat_get_data(self.ptr) }
     }
 
-    // debug
-    pub fn print(&self) {
-        println!(
-            "dims {}, c {}, h {}, w {}, elemsize {}",
-            self.get_dims(),
-            self.get_c(),
-            self.get_h(),
-            self.get_w(),
-            self.get_elemsize()
-        );
+    pub fn ptr(&self) -> ncnn_mat_t {
+        self.ptr
+    }
+
+    pub fn mut_ptr(&mut self) -> *mut ncnn_mat_t {
+        &mut self.ptr
+    }
+}
+
+impl fmt::Debug for Mat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Mat")
+            .field("dims", &self.get_dims())
+            .field("c", &self.get_c())
+            .field("h", &self.get_h())
+            .field("w", &self.get_w())
+            .field("elemsize", &self.get_elemsize())
+            .finish()
     }
 }
 

--- a/ncnn-rs/src/net.rs
+++ b/ncnn-rs/src/net.rs
@@ -1,7 +1,7 @@
 use crate::datareader::DataReader;
 use ncnn_bind::*;
 use std::ffi::CString;
-use std::os::raw::c_char;
+use std::marker::PhantomData;
 
 pub struct Net {
     ptr: ncnn_net_t,
@@ -28,15 +28,13 @@ impl Net {
 
     pub fn load_param(&self, path: &str) -> i32 {
         let c_str = CString::new(path).unwrap();
-        let c_ptr = c_str.as_ptr() as *const c_char;
-        let ret = unsafe { ncnn_net_load_param(self.ptr, c_ptr) };
+        let ret = unsafe { ncnn_net_load_param(self.ptr, c_str.as_ptr()) };
         ret
     }
 
     pub fn load_model(&self, path: &str) -> i32 {
         let c_str = CString::new(path).unwrap();
-        let c_ptr = c_str.as_ptr() as *const c_char;
-        let ret = unsafe { ncnn_net_load_model(self.ptr, c_ptr) };
+        let ret = unsafe { ncnn_net_load_model(self.ptr, c_str.as_ptr()) };
         ret
     }
 
@@ -44,12 +42,12 @@ impl Net {
         unsafe { ncnn_net_load_model_datareader(self.ptr, dr.get()) }
     }
 
-    pub fn create_extractor(&self) -> Extractor {
+    pub fn create_extractor(&self) -> Extractor<'_> {
         let ptr;
         unsafe {
             ptr = ncnn_extractor_create(self.ptr);
         }
-        Extractor { ptr }
+        Extractor::from_ptr(ptr)
     }
 }
 
@@ -61,33 +59,37 @@ impl Drop for Net {
     }
 }
 
-pub struct Extractor {
+pub struct Extractor<'a> {
     ptr: ncnn_extractor_t,
+    _phantom: PhantomData<&'a ()>,
 }
 
-impl Extractor {
-    pub fn set_option(&self, opt: &crate::option::Option) {
+impl<'a> Extractor<'a> {
+    fn from_ptr(ptr: ncnn_extractor_t) -> Self {
+        Self {
+            ptr,
+            _phantom: PhantomData::default(),
+        }
+    }
+
+    pub fn set_option(&mut self, opt: &crate::option::Option) {
         unsafe { ncnn_extractor_set_option(self.ptr, opt.get()) };
     }
 
-    pub fn input(&self, name: &str, mat: &crate::mat::Mat) -> i32 {
+    pub fn input(&mut self, name: &str, mat: &'a crate::mat::Mat) -> i32 {
         let c_str = CString::new(name).unwrap();
-        let c_ptr = c_str.as_ptr() as *const c_char;
-
-        let stat = unsafe { ncnn_extractor_input(self.ptr, c_ptr, mat.get()) };
+        let stat = unsafe { ncnn_extractor_input(self.ptr, c_str.as_ptr(), mat.ptr()) };
         stat
     }
 
-    pub fn extract(&self, name: &str, mat: &crate::mat::Mat) -> i32 {
+    pub fn extract(self, name: &str, mat: &mut crate::mat::Mat) -> i32 {
         let c_str = CString::new(name).unwrap();
-        let c_ptr = c_str.as_ptr() as *const c_char;
-
-        let stat = unsafe { ncnn_extractor_extract(self.ptr, c_ptr, &mut mat.get()) };
+        let stat = unsafe { ncnn_extractor_extract(self.ptr, c_str.as_ptr(), mat.mut_ptr()) };
         stat
     }
 }
 
-impl Drop for Extractor {
+impl<'a> Drop for Extractor<'a> {
     fn drop(&mut self) {
         unsafe {
             ncnn_extractor_destroy(self.ptr);

--- a/ncnn-rs/src/net.rs
+++ b/ncnn-rs/src/net.rs
@@ -16,33 +16,29 @@ impl Net {
         Net { ptr }
     }
 
-    pub fn get(&self) -> ncnn_net_t {
-        self.ptr
-    }
-
-    pub fn set_option(&self, opt: &crate::option::Option) {
+    pub fn set_option(&mut self, opt: &crate::option::Option) {
         unsafe {
-            ncnn_net_set_option(self.ptr, opt.get());
+            ncnn_net_set_option(self.ptr, opt.ptr());
         }
     }
 
-    pub fn load_param(&self, path: &str) -> i32 {
+    pub fn load_param(&mut self, path: &str) -> i32 {
         let c_str = CString::new(path).unwrap();
         let ret = unsafe { ncnn_net_load_param(self.ptr, c_str.as_ptr()) };
         ret
     }
 
-    pub fn load_model(&self, path: &str) -> i32 {
+    pub fn load_model(&mut self, path: &str) -> i32 {
         let c_str = CString::new(path).unwrap();
         let ret = unsafe { ncnn_net_load_model(self.ptr, c_str.as_ptr()) };
         ret
     }
 
-    pub fn load_model_datareader(&self, dr: &DataReader) -> i32 {
-        unsafe { ncnn_net_load_model_datareader(self.ptr, dr.get()) }
+    pub fn load_model_datareader(&mut self, dr: &DataReader) -> i32 {
+        unsafe { ncnn_net_load_model_datareader(self.ptr, dr.ptr()) }
     }
 
-    pub fn create_extractor(&self) -> Extractor<'_> {
+    pub fn create_extractor(&mut self) -> Extractor<'_> {
         let ptr;
         unsafe {
             ptr = ncnn_extractor_create(self.ptr);
@@ -73,7 +69,7 @@ impl<'a> Extractor<'a> {
     }
 
     pub fn set_option(&mut self, opt: &crate::option::Option) {
-        unsafe { ncnn_extractor_set_option(self.ptr, opt.get()) };
+        unsafe { ncnn_extractor_set_option(self.ptr, opt.ptr()) };
     }
 
     pub fn input(&mut self, name: &str, mat: &'a crate::mat::Mat) -> i32 {

--- a/ncnn-rs/src/option.rs
+++ b/ncnn-rs/src/option.rs
@@ -14,7 +14,7 @@ impl Option {
         Option { ptr }
     }
 
-    pub fn set_num_threads(&self, num_threads: u32) {
+    pub fn set_num_threads(&mut self, num_threads: u32) {
         unsafe {
             ncnn_option_set_num_threads(self.ptr, num_threads as c_int);
         }
@@ -25,7 +25,7 @@ impl Option {
         num as u32
     }
 
-    pub fn get(&self) -> ncnn_option_t {
+    pub(crate) fn ptr(&self) -> ncnn_option_t {
         self.ptr
     }
 }
@@ -43,7 +43,7 @@ mod tests {
     #[test]
     fn get_cpu_info() {
         use crate::option::*;
-        let opt = Option::new();
+        let mut opt = Option::new();
         opt.set_num_threads(4);
         assert_eq!(4, opt.get_num_threads());
     }


### PR DESCRIPTION
This fixes a couple of safety bugs:
- Set proper mutability for various methods
- Add lifetime to `Extractor`, otherwise `Net` can be dropped while `Extractor` is still in use
- Consume `Extractor` within `extract` method as `Extractor` can only be used once