### PR TITLE
add vcpkg support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "bindgen",
  "cmake",
  "libc",
+ "vcpkg",
 ]
 
 [[package]]
@@ -205,6 +206,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Use prebuilt ncnn:
 $ export NCNN_DIR="/path/to/your/ncnn/lib"
 ```
 
+Or use vcpkg
+```bash
+vcpkg install ncnn:x64-windows-static-md
+cargo run --example get_version
+```
+
 ## Linking
 
 By default library uses dynamic **linking on linux** and **static linking on windows**.

--- a/ncnn-bind/Cargo.toml
+++ b/ncnn-bind/Cargo.toml
@@ -23,3 +23,4 @@ libc = "0.2"
 [build-dependencies]
 cmake = "0.1"
 bindgen    = { version = "0.59.2", default-features = false, features = ["runtime"] }
+vcpkg = "0.2.15"

--- a/ncnn-bind/build.rs
+++ b/ncnn-bind/build.rs
@@ -117,7 +117,7 @@ fn link_vulkan() {
     println!("cargo:rustc-link-lib={}", lib);
 }
 
-fn main() {
+fn build_ncnn() -> Vec<PathBuf> {
     println!("cargo:rerun-if-env-changed=NCNN_DIR");
     println!("cargo:rerun-if-env-changed=NCNN_TAG");
 
@@ -156,6 +156,17 @@ fn main() {
     if cfg!(feature = "vulkan") {
         link_vulkan();
     }
+    return include_paths;
+}
+
+fn main() {
+    let include_paths = if let Ok(vcpkg_lib) = vcpkg::find_package("ncnn")
+    {
+        vec![vcpkg_lib.include_paths[0].join("ncnn")]
+    } else {
+        build_ncnn()
+    };
+
 
     let header = search_include(&include_paths, "c_api.h");
 


### PR DESCRIPTION
Tested on Windows 10 use static linking, but ncnn on vcpkg is not support vulkan now